### PR TITLE
Fix KeyValueStore unarchiving for Darwin

### DIFF
--- a/PAL/Darwin/HAPPlatformKeyValueStore.m
+++ b/PAL/Darwin/HAPPlatformKeyValueStore.m
@@ -25,7 +25,7 @@ void HAPPlatformKeyValueStoreCreate(
 
     NSError* error;
     NSData* data = [NSData dataWithContentsOfFile:@(keyValueStore->rootDirectory) options:0 error:&error];
-    KeyValueStore = [NSKeyedUnarchiver unarchivedObjectOfClasses:[NSSet setWithArray:@[[NSArray class], [NSData class]]]
+    KeyValueStore = [NSKeyedUnarchiver unarchivedObjectOfClasses:[NSSet setWithArray:@[[NSMutableDictionary class]]]
                                                         fromData:data
                                                            error:&error];
     if (!KeyValueStore) {


### PR DESCRIPTION
Loading `KeyValueStore` from file did not work because `unarchivedObjectOfClasses` did not contain `NSMutableDictionary` although the root object is a `NSMutableDictionary`.