### PR TITLE
Build with -Wextra

### DIFF
--- a/Applications/Lightbulb/App.c
+++ b/Applications/Lightbulb/App.c
@@ -183,7 +183,7 @@ void AccessoryNotification(
         const HAPAccessory* accessory,
         const HAPService* service,
         const HAPCharacteristic* characteristic,
-        void* ctx) {
+        void* ctx HAP_UNUSED) {
     HAPLogInfo(&kHAPLog_Default, "Accessory Notification");
 
     HAPAccessoryServerRaiseEvent(accessoryConfiguration.server, characteristic, service, accessory);
@@ -236,9 +236,9 @@ const HAPAccessory* AppGetAccessoryInfo() {
 }
 
 void AppInitialize(
-        HAPAccessoryServerOptions* hapAccessoryServerOptions,
-        HAPPlatform* hapPlatform,
-        HAPAccessoryServerCallbacks* hapAccessoryServerCallbacks) {
+        HAPAccessoryServerOptions* hapAccessoryServerOptions HAP_UNUSED,
+        HAPPlatform* hapPlatform HAP_UNUSED,
+        HAPAccessoryServerCallbacks* hapAccessoryServerCallbacks HAP_UNUSED) {
     /*no-op*/
 }
 

--- a/Applications/Lock/App.c
+++ b/Applications/Lock/App.c
@@ -327,9 +327,9 @@ const HAPAccessory* AppGetAccessoryInfo() {
 }
 
 void AppInitialize(
-        HAPAccessoryServerOptions* hapAccessoryServerOptions,
-        HAPPlatform* hapPlatform,
-        HAPAccessoryServerCallbacks* hapAccessoryServerCallbacks) {
+        HAPAccessoryServerOptions* hapAccessoryServerOptions HAP_UNUSED,
+        HAPPlatform* hapPlatform HAP_UNUSED,
+        HAPAccessoryServerCallbacks* hapAccessoryServerCallbacks HAP_UNUSED) {
     /*no-op*/
 }
 

--- a/Applications/Main.c
+++ b/Applications/Main.c
@@ -277,7 +277,7 @@ static void InitializeBLE() {
 }
 #endif
 
-int main(int argc, char* _Nullable argv[_Nullable]) {
+int main(int argc HAP_UNUSED, char* _Nullable argv[_Nullable] HAP_UNUSED) {
     HAPAssert(HAPGetCompatibilityVersion() == HAP_COMPATIBILITY_VERSION);
 
     // Initialize global platform objects.

--- a/Build/Makefile
+++ b/Build/Makefile
@@ -10,7 +10,7 @@ PAL ?= $(PLATFORM)
 BUILD_TYPE ?= Debug
 
 SRC_DIRS := HAP External/HTTP External/JSON External/Base64 PAL PAL/Mock
-CFLAGS := -Wall -Werror -DHAP_ENABLE_DEVELOPMENT_ONLY_CODE=1
+CFLAGS := -Wall -Wextra -Werror -DHAP_ENABLE_DEVELOPMENT_ONLY_CODE=1
 LDFLAGS :=
 
 BUILD_TYPES := Debug Test Release

--- a/Build/Makefile.Darwin
+++ b/Build/Makefile.Darwin
@@ -21,7 +21,7 @@ DEBUGGER := lldb
 SRC_DIRS_Darwin := PAL/Darwin Common
 CRYPTO_Darwin := PAL/Crypto/OpenSSL PAL/Crypto/MbedTLS
 
-CFLAGS_m := -fobjc-arc -Wno-ignored-attributes -Wno-unguarded-availability-new -Wno-availability -Wunused-function
+CFLAGS_m := -fobjc-arc -Wno-ignored-attributes -Wno-unguarded-availability-new -Wno-availability -Wunused-function -Wno-error=missing-method-return-type -Wno-error=unused-parameter
 CFLAGS_Darwin := $(CFLAGS_$(TARGET_FLAVOR)) $(CFLAGS_BLE) $(CFLAGS_IP)
 CFLAGS_Darwin += -DDARWIN=1 -Werror=unused-function
 CFLAGS_Darwin += -Wno-expansion-to-defined -Wno-nullability-completeness -Wno-deprecated-declarations

--- a/HAP/HAPIPAccessoryServer.c
+++ b/HAP/HAPIPAccessoryServer.c
@@ -564,7 +564,7 @@ static void prepare_reading_request(HAPIPSessionDescriptor* session) {
 
 static void handle_input(HAPIPSessionDescriptor* session);
 
-static void post_resource(HAPIPSessionDescriptor* session) {
+static void post_resource(HAPIPSessionDescriptor* session HAP_UNUSED) {
 }
 
 static void put_prepare(HAPIPSessionDescriptor* session) {

--- a/PAL/Crypto/MbedTLS/HAPMbedTLS.c
+++ b/PAL/Crypto/MbedTLS/HAPMbedTLS.c
@@ -95,7 +95,7 @@ int HAP_ed25519_verify(
 
 #endif
 
-static int blinding_rng(void* context, uint8_t* buffer, size_t n) {
+static int blinding_rng(void* context HAP_UNUSED, uint8_t* buffer, size_t n) {
     HAPPlatformRandomNumberFill(buffer, n);
     return 0;
 }
@@ -577,9 +577,9 @@ void chacha20_poly1305_final(HAP_chacha20_poly1305_ctx* ctx, uint8_t tag[CHACHA2
 
 void HAP_chacha20_poly1305_init(
         HAP_chacha20_poly1305_ctx* ctx,
-        const uint8_t* n,
-        size_t n_len,
-        const uint8_t k[CHACHA20_POLY1305_KEY_BYTES]) {
+        const uint8_t* n HAP_UNUSED,
+        size_t n_len HAP_UNUSED,
+        const uint8_t k[CHACHA20_POLY1305_KEY_BYTES] HAP_UNUSED) {
     mbedtls_chachapoly_context_Handle* handle = (mbedtls_chachapoly_context_Handle*) ctx;
     handle->ctx = NULL;
 }

--- a/PAL/Crypto/OpenSSL/HAPOpenSSL.c
+++ b/PAL/Crypto/OpenSSL/HAPOpenSSL.c
@@ -55,7 +55,7 @@ void HAP_ed25519_sign(
         const uint8_t* m,
         size_t m_len,
         const uint8_t sk[ED25519_SECRET_KEY_BYTES],
-        const uint8_t pk[ED25519_PUBLIC_KEY_BYTES]) {
+        const uint8_t pk[ED25519_PUBLIC_KEY_BYTES] HAP_UNUSED) {
     WITH_PKEY(key, EVP_PKEY_new_raw_private_key(EVP_PKEY_ED25519, NULL, sk, ED25519_SECRET_KEY_BYTES), {
         WITH_CTX(EVP_MD_CTX, EVP_MD_CTX_new(), {
             int ret = EVP_DigestSignInit(ctx, NULL, NULL, NULL, key);
@@ -436,9 +436,9 @@ static void copy_and_free_if_overlapping(uint8_t** tmp, uint8_t** out, size_t n)
 
 void HAP_chacha20_poly1305_init(
         HAP_chacha20_poly1305_ctx* ctx,
-        const uint8_t* n,
-        size_t n_len,
-        const uint8_t k[CHACHA20_POLY1305_KEY_BYTES]) {
+        const uint8_t* n HAP_UNUSED,
+        size_t n_len HAP_UNUSED,
+        const uint8_t k[CHACHA20_POLY1305_KEY_BYTES] HAP_UNUSED) {
     EVP_CIPHER_CTX_Handle* handle = (EVP_CIPHER_CTX_Handle*) ctx;
     handle->ctx = NULL;
 }
@@ -469,7 +469,7 @@ void HAP_chacha20_poly1305_update_enc(
         int c_len;
         ret = EVP_EncryptUpdate(handle->ctx, use_temporary_if_overlapping(&tmp, m, c, m_len), &c_len, m, m_len);
         copy_and_free_if_overlapping(&tmp, &c, m_len);
-        HAPAssert(ret == 1 && c_len == m_len);
+        HAPAssert(ret == 1 && (size_t) c_len == m_len);
     }
 }
 
@@ -484,7 +484,7 @@ void HAP_chacha20_poly1305_update_enc_aad(
     EVP_CIPHER_CTX_Handle* handle = (EVP_CIPHER_CTX_Handle*) ctx;
     int a_out;
     int ret = EVP_EncryptUpdate(handle->ctx, NULL, &a_out, a, a_len);
-    HAPAssert(ret == 1 && a_out == a_len);
+    HAPAssert(ret == 1 && (size_t) a_out == a_len);
 }
 
 void HAP_chacha20_poly1305_final_enc(HAP_chacha20_poly1305_ctx* ctx, uint8_t tag[CHACHA20_POLY1305_TAG_BYTES]) {
@@ -537,7 +537,7 @@ void HAP_chacha20_poly1305_update_dec_aad(
     EVP_CIPHER_CTX_Handle* handle = (EVP_CIPHER_CTX_Handle*) ctx;
     int a_out;
     int ret = EVP_DecryptUpdate(handle->ctx, NULL, &a_out, a, a_len);
-    HAPAssert(ret == 1 && a_out == a_len);
+    HAPAssert(ret == 1 && (size_t) a_out == a_len);
 }
 
 int HAP_chacha20_poly1305_final_dec(HAP_chacha20_poly1305_ctx* ctx, const uint8_t tag[CHACHA20_POLY1305_TAG_BYTES]) {
@@ -567,7 +567,7 @@ void HAP_aes_ctr_encrypt(HAP_aes_ctr_ctx* ctx, uint8_t* ct, const uint8_t* pt, s
     EVP_CIPHER_CTX_Handle* handle = (EVP_CIPHER_CTX_Handle*) ctx;
     int ct_len;
     int ret = EVP_EncryptUpdate(handle->ctx, ct, &ct_len, pt, pt_len);
-    HAPAssert(ret == 1 && ct_len == pt_len);
+    HAPAssert(ret == 1 && (size_t) ct_len == pt_len);
 }
 
 void HAP_aes_ctr_decrypt(HAP_aes_ctr_ctx* ctx, uint8_t* pt, const uint8_t* ct, size_t ct_len) {

--- a/PAL/Darwin/HAPPlatformBLEPeripheralManager.m
+++ b/PAL/Darwin/HAPPlatformBLEPeripheralManager.m
@@ -186,6 +186,8 @@ static id pop(NSMutableArray* array) {
     dispatch_async(dispatch_get_main_queue(), ^{
         HAPLog(&logObject, "willRestoreState");
     });
+
+    (void) dict;
 }
 
 - (void)peripheralManager:(CBPeripheralManager*)peripheral didAddService:(CBService*)service error:(NSError*)error {
@@ -194,6 +196,9 @@ static id pop(NSMutableArray* array) {
     dispatch_async(dispatch_get_main_queue(), ^{
         HAPLog(&logObject, "didAddService");
     });
+
+    (void) service;
+    (void) error;
 }
 
 - (void)peripheralManagerDidStartAdvertising:(CBPeripheralManager*)peripheral error:(NSError*)error {
@@ -202,6 +207,9 @@ static id pop(NSMutableArray* array) {
     dispatch_async(dispatch_get_main_queue(), ^{
         HAPLog(&logObject, "peripheralManagerDidStartAdvertising");
     });
+
+    (void) peripheral;
+    (void) error;
 }
 
 - (void)peripheralManager:(CBPeripheralManager*)peripheral
@@ -214,6 +222,8 @@ static id pop(NSMutableArray* array) {
 
         [self updateCentralConnection:central];
     });
+
+    (void) characteristic;
 }
 
 - (void)peripheralManager:(CBPeripheralManager*)peripheral
@@ -226,6 +236,9 @@ static id pop(NSMutableArray* array) {
 
         [self updateCentralConnection:nil];
     });
+
+    (void) central;
+    (void) characteristic;
 }
 
 - (void)peripheralManagerIsReadyToUpdateSubscribers:(CBPeripheralManager*)peripheral {
@@ -303,6 +316,7 @@ static id pop(NSMutableArray* array) {
 }
 
 - (uint16_t)getHandleForCentral:(CBCentral*)central {
+    (void) central;
     return [self getHandleForString:_connectedCentral.identifier.UUIDString];
 }
 
@@ -579,7 +593,7 @@ HAP_RESULT_USE_CHECK
 HAPError HAPPlatformBLEPeripheralManagerAddDescriptor(
         HAPPlatformBLEPeripheralManagerRef blePeripheralManager,
         const HAPPlatformBLEPeripheralManagerUUID* type,
-        HAPPlatformBLEPeripheralManagerDescriptorProperties properties,
+        HAPPlatformBLEPeripheralManagerDescriptorProperties properties HAP_UNUSED,
         const void* _Nullable constBytes,
         size_t constNumBytes,
         HAPPlatformBLEPeripheralManagerAttributeHandle* descriptorHandle) {
@@ -647,7 +661,7 @@ void HAPPlatformBLEPeripheralManagerStopAdvertising(HAPPlatformBLEPeripheralMana
 
 void HAPPlatformBLEPeripheralManagerCancelCentralConnection(
         HAPPlatformBLEPeripheralManagerRef blePeripheralManager,
-        HAPPlatformBLEPeripheralManagerConnectionHandle connectionHandle) {
+        HAPPlatformBLEPeripheralManagerConnectionHandle connectionHandle HAP_UNUSED) {
     HAPPrecondition(blePeripheralManager);
 
     HAPLog(&logObject, __func__);

--- a/PAL/Darwin/HAPPlatformServiceDiscovery.m
+++ b/PAL/Darwin/HAPPlatformServiceDiscovery.m
@@ -16,6 +16,7 @@ void HAPPlatformServiceDiscoveryCreate(
         HAPPlatformServiceDiscoveryRef serviceDiscovery,
         const HAPPlatformServiceDiscoveryOptions* options) {
     HAPPrecondition(serviceDiscovery);
+    (void) options;
 }
 
 void HAPPlatformServiceDiscoveryRegister(

--- a/PAL/Darwin/HAPPlatformTCPStreamManager.m
+++ b/PAL/Darwin/HAPPlatformTCPStreamManager.m
@@ -44,8 +44,8 @@ static NSMutableArray<Connection*>* socketsWaitingToBeAccepted = nil;
 static NSMutableArray<Connection*>* connections = nil;
 
 void HAPPlatformTCPStreamManagerCreate(
-        HAPPlatformTCPStreamManagerRef _Nonnull tcpStreamManager,
-        const HAPPlatformTCPStreamManagerOptions* options) {
+        HAPPlatformTCPStreamManagerRef _Nonnull tcpStreamManager HAP_UNUSED,
+        const HAPPlatformTCPStreamManagerOptions* options HAP_UNUSED) {
     socketsWaitingToBeAccepted = [[NSMutableArray alloc] init];
     connections = [[NSMutableArray alloc] init];
 }
@@ -129,7 +129,10 @@ static void WaitForMoreDataInBackground(Connection* connection) {
             connection.socket,
             1,
             4096,
-            ^(dispatch_data_t data, nw_content_context_t context, bool is_complete, nw_error_t error) {
+            ^(dispatch_data_t data,
+              nw_content_context_t context HAP_UNUSED,
+              bool is_complete HAP_UNUSED,
+              nw_error_t error) {
                 if (error) {
                     return;
                 }

--- a/PAL/Mock/HAPPlatformBLEPeripheralManager.c
+++ b/PAL/Mock/HAPPlatformBLEPeripheralManager.c
@@ -142,8 +142,8 @@ HAPError HAPPlatformBLEPeripheralManagerAddCharacteristic(
         HAPPlatformBLEPeripheralManagerRef _Nonnull blePeripheralManager,
         const HAPPlatformBLEPeripheralManagerUUID* _Nonnull type,
         HAPPlatformBLEPeripheralManagerCharacteristicProperties properties,
-        const void* _Nullable constBytes,
-        size_t constNumBytes,
+        const void* _Nullable constBytes HAP_UNUSED,
+        size_t constNumBytes HAP_UNUSED,
         HAPPlatformBLEPeripheralManagerAttributeHandle* _Nonnull valueHandle,
         HAPPlatformBLEPeripheralManagerAttributeHandle* _Nullable cccDescriptorHandle) {
     HAPPrecondition(blePeripheralManager);
@@ -231,8 +231,8 @@ HAPError HAPPlatformBLEPeripheralManagerAddDescriptor(
         HAPPlatformBLEPeripheralManagerRef _Nonnull blePeripheralManager,
         const HAPPlatformBLEPeripheralManagerUUID* _Nonnull type,
         HAPPlatformBLEPeripheralManagerDescriptorProperties properties,
-        const void* _Nullable constBytes,
-        size_t constNumBytes,
+        const void* _Nullable constBytes HAP_UNUSED,
+        size_t constNumBytes HAP_UNUSED,
         HAPPlatformBLEPeripheralManagerAttributeHandle* _Nonnull descriptorHandle) {
     HAPPrecondition(blePeripheralManager);
     HAPPrecondition(!blePeripheralManager->didPublishAttributes);

--- a/Tests/HAPAccessorySetupGetSetupHashTest.c
+++ b/Tests/HAPAccessorySetupGetSetupHashTest.c
@@ -43,7 +43,7 @@ int Test(int argc, const char* argv[]) {
     return 0;
 }
 
-int main(int argc, char* argv[]) {
+int main(int argc HAP_UNUSED, char* argv[] HAP_UNUSED) {
     for (size_t i = 0; i < HAPArrayCount(TestArgs); ++i) {
         HAPAssert(Test(4, TestArgs[i]) == 0);
     }

--- a/Tests/HAPAccessorySetupGetSetupPayloadTest.c
+++ b/Tests/HAPAccessorySetupGetSetupPayloadTest.c
@@ -68,7 +68,7 @@ int Test(int argc, const char* argv[]) {
     return 0;
 }
 
-int main(int argc, char* argv[]) {
+int main(int argc HAP_UNUSED, char* argv[] HAP_UNUSED) {
     for (size_t i = 0; i < HAPArrayCount(TestArgs); ++i) {
         HAPAssert(Test(8, TestArgs[i]) == 0);
     }

--- a/Tests/HAPBLETransactionParseRequestTest.c
+++ b/Tests/HAPBLETransactionParseRequestTest.c
@@ -127,7 +127,7 @@ static int Test(int argc, const char* argv[]) {
     return 0;
 }
 
-int main(int argc, char* argv[]) {
+int main(int argc HAP_UNUSED, char* argv[] HAP_UNUSED) {
     for (size_t i = 0; i < HAPArrayCount(TestArgs); ++i) {
         HAPAssert(Test(TestArgs[i][6] ? 7 : 6, TestArgs[i]) == 0);
     }


### PR DESCRIPTION
Fix compile errors in current codebase - mainly unused arguments.

Some ObjC headers in XCode have unused arguments, so those need to be excepted.