### PR TITLE
Build AccessorySetupGenerator against host PAL instead of mock

### DIFF
--- a/Build/Makefile
+++ b/Build/Makefile
@@ -166,7 +166,7 @@ $(foreach protocol,$(PROTOCOLS),$(foreach app,$(APPS_LIST),$(foreach crypto,$(CR
 # Build AccessorySetupGenerator Tool
 ACCESSORY_SETUP_GENERATOR:= Tools/AccessorySetupGenerator
 $(call build_module,$(ACCESSORY_SETUP_GENERATOR),$(call all_sources_in,$(ACCESSORY_SETUP_GENERATOR)))
-$(foreach crypto,$(CRYPTO_MODULES),$(call build_executable,$(ACCESSORY_SETUP_GENERATOR),$(crypto),,$(ACCESSORY_SETUP_GENERATOR) $(CORE) Mock $(crypto)))
+$(foreach crypto,$(CRYPTO_MODULES),$(call build_executable,$(ACCESSORY_SETUP_GENERATOR),$(crypto),,$(ACCESSORY_SETUP_GENERATOR) $(CORE) $(HOST) $(crypto)))
 
 info:
 	@echo "Compiler: $(COMPILER)"

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ MAKE := make -f Build/Makefile -j 8
 DOCKER := docker
 DOCKERFILE := Build/Docker/Dockerfile
 RUN := $(DOCKER) run \
+  -e HOST \
   -e APPS \
   -e BUILD_TYPE \
   -e LOG_LEVEL \


### PR DESCRIPTION
Prevents fixed salt for setup code.