### PR TITLE
Fix HAPPlatformTimer on Darwin

### DIFF
--- a/PAL/Darwin/HAPPlatformTimer.m
+++ b/PAL/Darwin/HAPPlatformTimer.m
@@ -9,7 +9,12 @@
 #import <Foundation/Foundation.h>
 
 static NSTimer* scheduleTimer(HAPTime deadline, HAPPlatformTimerCallback callback, void* _Nullable context) {
-    NSTimeInterval interval = ((NSTimeInterval) deadline) / 1000.0;
+    NSTimeInterval interval = 0;
+    HAPTime currentTime = HAPPlatformClockGetCurrent();
+
+    if (deadline > currentTime) {
+        interval = ((NSTimeInterval)(deadline - currentTime)) / 1000.0;
+    }
 
     NSTimer* t = [NSTimer
             scheduledTimerWithTimeInterval:interval


### PR DESCRIPTION
The function scheduleTimer treated deadline
argument as relative time instead of absolute time