### PR TITLE
Fix builds when using recent Docker installations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ endif
 TARGET ?= $(HOST)
 BUILD_TYPE ?= Debug
 MAKE := make -f Build/Makefile -j $(shell $(NPROC))
-DOCKER_EXE := docker
+DOCKER_EXE := DOCKER_BUILDKIT=0 docker
 DOCKER ?= 1
 
 DOCKERFILE := Build/Docker/Dockerfile


### PR DESCRIPTION
This fixes issue #65

New installs of Docker Desktop as of version 2.4.0 enable BuildKit by default, which changes the format of the output of the "docker build" command.  The Makefile attempts to parse this output to get the ID of the image it builds (line 30 of the Makefile), but fails if BuildKit is enabled because the format is different. 

Existing installs of Docker upgraded to this version are not affected, as the configuration is not changed, but this fix makes sure that BuildKit is disabled regardless of the default setting so that the output is in the format that the Makefile expects.