### PR TITLE
Added service support for IP cameras

### DIFF
--- a/HAP/HAP.h
+++ b/HAP/HAP.h
@@ -3392,6 +3392,9 @@ HAP_ENUM_BEGIN(uint8_t, HAPAccessoryCategory) {
      */
     kHAPAccessoryCategory_RangeExtenders = 16,
 
+    /** IP Cameras. */
+    kHAPAccessoryCategory_IPCameras = 17,
+
     /** Air Purifiers. */
     kHAPAccessoryCategory_AirPurifiers = 19,
 

--- a/HAP/HAPServiceTypes.c
+++ b/HAP/HAPServiceTypes.c
@@ -83,3 +83,9 @@ const HAPUUID kHAPServiceType_IrrigationSystem = HAPUUIDCreateAppleDefined(0xCF)
 const HAPUUID kHAPServiceType_Valve = HAPUUIDCreateAppleDefined(0xD0);
 
 const HAPUUID kHAPServiceType_Faucet = HAPUUIDCreateAppleDefined(0xD7);
+
+const HAPUUID kHAPServiceType_CameraRTPStreamManagement = HAPUUIDCreateAppleDefined(0x110);
+
+const HAPUUID kHAPServiceType_Microphone = HAPUUIDCreateAppleDefined(0x112);
+
+const HAPUUID kHAPServiceType_Speaker = HAPUUIDCreateAppleDefined(0x113);

--- a/HAP/HAPServiceTypes.h
+++ b/HAP/HAPServiceTypes.h
@@ -1096,6 +1096,25 @@ extern const HAPUUID kHAPServiceType_Valve;
 extern const HAPUUID kHAPServiceType_Faucet;
 /**@}*/
 
+/**@{*/
+#define kHAPServiceDebugDescription_CameraRTPStreamManagement "camera-rtp-stream-management"
+
+extern const HAPUUID kHAPServiceType_CameraRTPStreamManagement;
+/**@}*/
+
+/**@{*/
+#define kHAPServiceDebugDescription_Microphone "microphone"
+
+extern const HAPUUID kHAPServiceType_Microphone;
+/**@}*/
+
+/**@{*/
+#define kHAPServiceDebugDescription_Speaker "speaker"
+
+extern const HAPUUID kHAPServiceType_Speaker;
+/**@}*/
+
+
 #if __has_feature(nullability)
 #pragma clang assume_nonnull end
 #endif

--- a/Tests/Harness/HAPTestController.c
+++ b/Tests/Harness/HAPTestController.c
@@ -343,6 +343,7 @@ static void EnumerateHAPTXTRecordsCallback(
             case kHAPAccessoryCategory_WindowCoverings:
             case kHAPAccessoryCategory_ProgrammableSwitches:
             case kHAPAccessoryCategory_RangeExtenders:
+            case kHAPAccessoryCategory_IPCameras:
             case kHAPAccessoryCategory_AirPurifiers:
             case kHAPAccessoryCategory_Heaters:
             case kHAPAccessoryCategory_AirConditioners:
@@ -725,6 +726,7 @@ HAPError HAPDiscoverBLEAccessoryServer(
                     case kHAPAccessoryCategory_WindowCoverings:
                     case kHAPAccessoryCategory_ProgrammableSwitches:
                     case kHAPAccessoryCategory_RangeExtenders:
+                    case kHAPAccessoryCategory_IPCameras:
                     case kHAPAccessoryCategory_AirPurifiers:
                     case kHAPAccessoryCategory_Heaters:
                     case kHAPAccessoryCategory_AirConditioners:


### PR DESCRIPTION
IP Camera Accessory category is documented in the Open Source ADK documentation however is not identified in HAP.h header.  As well, other required associated HAP Service Types are documented but not included.  This PR is an initial step to include IP Camera support in the ADK.

closes #86 