### PR TITLE
Makefile.Linux: use cc -dumpmachine 

### DIFF
--- a/Build/Makefile.Darwin
+++ b/Build/Makefile.Darwin
@@ -15,7 +15,7 @@ XCODE_SDK_PATH := $(shell $(XCODE_RUN) --show-sdk-path)
 
 CC := $(shell $(XCODE_RUN) -find clang)
 AR := ar
-COMPILER := $(shell $(CC) --version | grep "Target:" | cut -d ' ' -f 2)
+COMPILER := $(shell $(CC) -dumpmachine)
 DEBUGGER := lldb
 
 SRC_DIRS_Darwin := PAL/Darwin Common

--- a/Build/Makefile.Linux
+++ b/Build/Makefile.Linux
@@ -1,7 +1,7 @@
 
 CC := clang
 AR := ar
-COMPILER := $(shell $(CC) --version | grep "Target:" | cut -d ' ' -f 2)
+COMPILER := $(shell $(CC) -dumpmachine)
 DEBUGGER := gdb
 
 SRC_DIRS_Linux := PAL/Linux

--- a/Build/Makefile.Raspi
+++ b/Build/Makefile.Raspi
@@ -1,7 +1,7 @@
 
 CC := clang
 AR := ar
-COMPILER := $(shell $(CC) --version | grep "Target:" | cut -d ' ' -f 2)
+COMPILER := $(shell $(CC) -dumpmachine)
 DEBUGGER := gdb
 
 SRC_DIRS_Raspi := PAL/Raspi

--- a/Documentation/getting_started.md
+++ b/Documentation/getting_started.md
@@ -67,17 +67,17 @@ is the SSH password; both of these were chosen during the initial `raspi_sdcard_
 ```
 
 ## Make options
-Commmand                         | Description
--------------------------------- | -------------------------------------------------------------------
-make ? | <ul><li>apps - Build all apps (Default)</li></li><li>test - Build unit tests</li><li>all - Build apps and unit tests</li></ul>
-make APPS=? | Space delimited names of the app to compile. <br><br>Example: `make APPS=“Lightbulb Lock”`<br><br> Default: All applications
-make BUILD_TYPE=? | Build type: <br><ul><li>Debug (Default)</li><li>Test</li><li>Release</li></ul>
-make CRYPTO=? | Supported cryptographic libraries: <br><ul><li>OpenSSL (Default)</li><li>MbedTLS</li></ul>Example: `make CRYPTO=MbedTLS apps`
-make DOCKER=? | Build with or without Docker: <br><ul><li>1 - Enable Docker during compilation (Default)</li><li>0 - Disable Docker during compilation</li></ul>
+Command              | Description
+-------------------- | -------------------------------------------------------------------
+make ?               | <ul><li>apps - Build all apps (Default)</li></li><li>test - Build unit tests</li><li>all - Build apps and unit tests</li></ul>
+make APPS=?          | Space delimited names of the app to compile. <br><br>Example: `make APPS="Lightbulb Lock"`<br><br> Default: All applications
+make BUILD_TYPE=?    | Build type: <br><ul><li>Debug (Default)</li><li>Test</li><li>Release</li></ul>
+make CRYPTO=?        | Supported cryptographic libraries: <br><ul><li>OpenSSL (Default)</li><li>MbedTLS</li></ul> Example: `make CRYPTO=MbedTLS apps`
+make DOCKER=?        | Build with or without Docker: <br><ul><li>1 - Enable Docker during compilation (Default)</li><li>0 - Disable Docker during compilation</li></ul>
 make LOG_LEVEL=level | <ul><li>0 - No logs are displayed (Default for release build)</li><li>1	- Error and Fault-level logs are displayed (Default for test build)</li><li>2 - Error, Fault-level and Info logs are displayed</li><li>3 - Error, Fault-level, Info and Debug logs are displayed (Default for debug build)</li></ul>
-make PROTOCOLS=? | Space delimited protocols supported by the applications: <br><ul><li>BLE</li><li>IP</li></ul><br>Example: `make PROTOCOLS=“IP BLE”`<br><br>Default: All protocols
-make TARGET=? | Build for a given target platform:<br><ul><li>Darwin</li><li>Linux</li></li><li>Raspi</li></ul>
-make USE_DISPLAY=? | Build with display support enabled:<br><ul><li>0 - Disable (Default)</li><li>1 - Enable</li></ul>
-make USE_HW_AUTH=? | Build with hardware authentication enabled: <br><ul><li>0 - Disable (Default)</li><li>1 - Enable</li></ul>
-make USE_NFC=? | Build with NFC enabled:<br><ul><li>0 - Disable (Default)</li><li>1 - Enable</li></ul>
-make USE_WAC=? | Build with WAC enabled:<br><ul><li>0 - Disable (Default)</li><li>1 - Enable</li></ul>
+make PROTOCOLS=?     | Space delimited protocols supported by the applications: <br><ul><li>BLE</li><li>IP</li></ul><br> Example: `make PROTOCOLS="IP BLE"`<br><br>Default: All protocols
+make TARGET=?        | Build for a given target platform:<br><ul><li>Darwin</li><li>Linux</li></li><li>Raspi</li></ul>
+make USE_DISPLAY=?   | Build with display support enabled:<br><ul><li>0 - Disable (Default)</li><li>1 - Enable</li></ul>
+make USE_HW_AUTH=?   | Build with hardware authentication enabled: <br><ul><li>0 - Disable (Default)</li><li>1 - Enable</li></ul>
+make USE_NFC=?       | Build with NFC enabled:<br><ul><li>0 - Disable (Default)</li><li>1 - Enable</li></ul>
+make USE_WAC=?       | Build with WAC enabled:<br><ul><li>0 - Disable (Default)</li><li>1 - Enable</li></ul>


### PR DESCRIPTION
Replace `$(CC) --version | grep "Target:" | cut -d ' ' -f 2)` with a simple `cc -dumpmachine`.
Actually the line above `CC := clang` is not needed anymore because we can build with gcc (and probably other compilers like Intel's icc).

Also I added a small improvement to getting_started.md