### PR TITLE
Fix the server engine is not uninstalled when the server is released.

### DIFF
--- a/HAP/HAPAccessoryServer.c
+++ b/HAP/HAPAccessoryServer.c
@@ -284,11 +284,11 @@ void HAPAccessoryServerRelease(HAPAccessoryServerRef* server_) {
 
     HAPMFiHWAuthRelease(&server->mfi);
 
-    HAPRawBufferZero(server_, sizeof *server_);
-
     if (server->transports.ip) {
         HAPNonnull(server->transports.ip)->serverEngine.uninstall();
     }
+
+    HAPRawBufferZero(server_, sizeof *server_);
 }
 
 HAP_RESULT_USE_CHECK


### PR DESCRIPTION
The following code will never be executed when calling `HAPAccessoryServerRelease()`.
```
if (server->transports.ip) {
    HAPNonnull(server->transports.ip)->serverEngine.uninstall();
}
```
